### PR TITLE
Integrate CronService into AuthService and tests (#46)

### DIFF
--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common'
+import { CronModule } from '~/cron/cron.module'
 import { ScenariosModule } from '~/scenarios/scenarios.module'
 import { SessionsModule } from '~/sessions/sessions.module'
 import { SimulationsModule } from '~/simulations/simulations.module'
@@ -9,7 +10,7 @@ import { AuthService } from './auth.service'
 @Module({
   controllers: [AuthController],
   exports: [AuthService],
-  imports: [UsersModule, SessionsModule, ScenariosModule, SimulationsModule],
+  imports: [UsersModule, SessionsModule, ScenariosModule, SimulationsModule, CronModule],
   providers: [AuthService],
 })
 export class AuthModule {}


### PR DESCRIPTION
Added CronService to AuthService and its module to handle user access updates after sign-up and sign-in. Updated test coverage to verify CronService calls.