### PR TITLE
Add support for selecting a privileged simulation

### DIFF
--- a/src/schemas/simulations/simulation.ts
+++ b/src/schemas/simulations/simulation.ts
@@ -51,7 +51,8 @@ export type TSimulationWithResults = z.infer<typeof ZSimulationWithResults>
 export const ZRequestPowerpoint = z.object({
   nextStep: z.string(),
   resultDate: z.coerce.date(),
-  selectedSimulations: z.array(z.string()),
+  selectedSimulations: z.array(z.string()).min(1).max(4),
+  privilegedSimulation: z.string().optional(),
 })
 
 export type TRequestPowerpoint = z.infer<typeof ZRequestPowerpoint>


### PR DESCRIPTION
Introduced the ability to designate a privileged simulation for PowerPoint exports, displayed prominently in both the UI and emails. Updated validation, UI components, and backend logic to handle this optional feature while ensuring seamless integration with existing functionalities.